### PR TITLE
Add segregation visualization navigation

### DIFF
--- a/html/maps.html
+++ b/html/maps.html
@@ -22,6 +22,9 @@
                     <li>
                         <a href="methods.html" class="navi" id="methods">Methods</a>
                     </li>
+                    <li>
+                        <a href="segregation-viz.html" class="navi" id="seg-viz">Segregation</a>
+                    </li>
                     <!-- <li>
                         <a href="about.html" class="navi" id="about">About</a>
                     </li> -->

--- a/html/segregation-viz.html
+++ b/html/segregation-viz.html
@@ -147,6 +147,7 @@
             <button onclick="resetAnimation()">Reset</button>
             <button onclick="clearPaths()">Clear Paths</button>
             <button onclick="toggleBars()">Toggle Bars</button>
+            <button onclick="goBack()">Back to Map</button>
         </div>
         
         <div class="legend">
@@ -670,7 +671,11 @@
         function toggleBars() {
             showBars = !showBars;
         }
-        
+
+        function goBack() {
+            window.location.href = 'maps.html';
+        }
+
         function clearPaths() {
             // Clear all path histories
             for (let person of people) {


### PR DESCRIPTION
## Summary
- link to segregation visualization from the map page
- add a back button on the segregation visualization page

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_68594fbe66b88331a278ac6ae3821b1f