### PR TITLE
Fix canvas height mismatch causing map overlay offset

### DIFF
--- a/html/segregation-viz.html
+++ b/html/segregation-viz.html
@@ -357,8 +357,10 @@
         
         // Resize canvas
         function resizeCanvas() {
-            canvas.width = window.innerWidth;
-            canvas.height = window.innerHeight;
+            // Match the canvas pixel size to its displayed size so
+            // coordinates from map.project align correctly even on mobile
+            canvas.width = canvas.clientWidth;
+            canvas.height = canvas.clientHeight;
         }
         
         // Person class with improved Mixing calculation


### PR DESCRIPTION
## Summary
- ensure canvas width/height sync with displayed size in segregation visualization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a4360f1c48331a04a67e729d2c9cc